### PR TITLE
Updates

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -14,3 +14,9 @@ package.xml
 **/tsconfig.json
 
 **/*.ts
+
+# Added by Illuminated Cloud
+/.illuminatedCloud/
+**/tsconfig*.json
+**/*.tsbuildinfo
+**/eslint.config.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,12 @@ robot/animal_shelter_starter/results/
 
 test_results.*
 /IlluminatedCloud/
+
+# Added by Illuminated Cloud
+.localdev/
+/out/
+target/
+node_modules/
+/.illuminatedCloud/
+**/tsconfig*.json
+**/*.tsbuildinfo

--- a/force-app/main/default/lwc/animalShelterSettingsEditor/animalShelterSettingsEditor.html
+++ b/force-app/main/default/lwc/animalShelterSettingsEditor/animalShelterSettingsEditor.html
@@ -13,7 +13,6 @@
                 <p class="slds-text-body_regular slds-var-m-bottom_medium">Here you can make changes to the default
                     settings which Animal Shelter Starter uses. Note: Settings are saved when they are changed.</p>
 
-
                 <lightning-tabset variant="vertical">
                     <lightning-tab label="Setup">
                         <div style="display: flex; flex-direction: column;">
@@ -21,21 +20,22 @@
                                 <lightning-layout-item flexibility="auto" padding="around-small">
                                     <p><b>Animal Shelter Starter - Setup Checklist</b></p>
                                     <p>If this is the first time you have used the Animal Shelter Starter Pack,
-                                         follow this checklist to confirm correct configuration.</p>
-                                         <p></p>
-                                        <ol>
-                                            <li>Enable Path</li>
-                                            <li>Update Page Layout assignments on the Animal Action Object</li>
-                                            <li>Update Page Layout assignments on the Location Object</li>
-                                            <li>Update Page Layout assignments on the Contact Object (optional)</li>
-                                            <li>Update Page Layout assignments on the Account Object (optional)</li>
-                                            <li>Load Breeds Data</li>
-                                            <li>Setup your Locations</li>
-                                            <li>Review and check Flows</li>
-                                            <li>Create a Account record for your Shelter which will be used as the default Animal Owner for animals coming into
-                                                the shelter</li>
-                                            <li>Review and check Custom Settings</li>
-                                        </ol>
+                                        follow this checklist to confirm correct configuration.</p>
+                                    <p></p>
+                                    <ol class="slds-list_ordered">
+                                        <li>Enable Path</li>
+                                        <li>Update Page Layout assignments on the Animal Action Object</li>
+                                        <li>Update Page Layout assignments on the Location Object</li>
+                                        <li>Update Page Layout assignments on the Contact Object (optional)</li>
+                                        <li>Update Page Layout assignments on the Account Object (optional)</li>
+                                        <li>Load Breeds Data</li>
+                                        <li>Setup your Locations</li>
+                                        <li>Review and check Flows</li>
+                                        <li>Create a Account record for your Shelter which will be used as the default
+                                            Animal Owner for animals coming into
+                                            the shelter</li>
+                                        <li>Review and check Custom Settings</li>
+                                    </ol>
                                 </lightning-layout-item>
                             </lightning-layout>
                             <hr />
@@ -173,6 +173,22 @@
                                     data-field="animalshelters__microchip_api_Token__c"></lightning-input>
                             </lightning-layout-item>
                         </lightning-layout>
+                        <br />
+                        <lightning-layout multiple-rows="false">
+                            <lightning-layout-item padding="around-small" size="6">
+                                <p><b>Allow Images from ChipNDoodle</b></p>
+                                <p>When enabled, this will allow image URLs to be returned from the API integration with
+                                    ChipNDoodle. This means that images could be loaded from external sources.</p>
+                            </lightning-layout-item>
+                            <lightning-layout-item padding="around-small" size="6">
+                                <div class="slds-form-element__control slds-float_right">
+                                    <lightning-input type="toggle" label="Allow Images"
+                                        checked={settings_data.animalshelters__Allow_Images__c}
+                                        onchange={handleBooleanChange}
+                                        data-field="animalshelters__Allow_Images__c"></lightning-input>
+                                </div>
+                            </lightning-layout-item>
+                        </lightning-layout>
                         <hr />
                         <lightning-layout multiple-rows="false">
                             <lightning-layout-item padding="around-small" size="6">
@@ -194,7 +210,8 @@
                             <lightning-layout-item padding="around-small" size="6">
                                 <p><b>Default Shelter Name</b></p>
                                 <p>Create an Account for your Shelter and enter the Account Name here.
-                                     By default incoming Animals will be given a Owner relationship with this Account.</p>
+                                    By default incoming Animals will be given a Owner relationship with this Account.
+                                </p>
                             </lightning-layout-item>
                             <lightning-layout-item padding="around-small" size="6">
                                 <lightning-input label="Default Shelter Name" type="text"

--- a/force-app/main/default/lwc/microchipLookup/microchipLookup.html
+++ b/force-app/main/default/lwc/microchipLookup/microchipLookup.html
@@ -1,6 +1,7 @@
 <template>
   <lightning-card title="Microchip Lookup" icon-name="custom:custom39">
-    <lightning-button icon-name="utility:refresh" onclick={getResults} slot="actions" title="Refresh" label="Refresh"></lightning-button>
+    <lightning-button icon-name="utility:refresh" onclick={getResults} slot="actions" title="Refresh"
+      label="Refresh"></lightning-button>
     <lightning-spinner if:true={isLoading}></lightning-spinner>
     <template lwc:if={resultsFound}>
 
@@ -15,18 +16,26 @@
           <template for:each={resultObject.responses} for:item="response">
             <lightning-accordion-section name={response.uid} label={response.database.name} key={response.uid}>
               <div class="slds-media">
+
                 <div class="slds-media__figure">
-                  <span class="slds-avatar slds-avatar_large">
-                    <img alt="Person name" src={response.image} title="User avatar" height="100px"
-                      onclick={handleImgClick} data-imgsrc={response.image} />
-                  </span>
+                  <template lwc:if={showImages}>
+                    <span class="slds-avatar slds-avatar_large">
+                      <img alt="Animal Image" src={response.image} title="Animal Image" height="100px"
+                        onclick={handleImgClick} data-imgsrc={response.image} />
+                    </span>
+                  </template>
+                  <template lwc:else>
+                    <lightning-avatar src="/bad/image/url.jpg" initials=""
+                      fallback-icon-name="utility:animal_and_nature" alternative-text="Placeholder Image"
+                      class="slds-m-right_small"></lightning-avatar>
+                  </template>
                 </div>
+
                 <div class="slds-media__body">
                   <h3 class="slds-text-heading_small">Animal Information</h3>
                   <p>Name: {response.name}</p>
                   <p>Species: {response.species}</p>
                   <p>Breed: {response.breed}</p>
-                  <p>Description: {response.breed}</p>
                   <p>
                     Date of Birth: {response.dob}
                   </p>
@@ -34,6 +43,9 @@
                   <h3 class="slds-text-heading_small">Contact Information</h3>
                   <p>Phone: {response.tel}</p>
                   <p>Email: {response.email}</p>
+                  <br />
+                  <h3 class="slds-text-heading_small">Database</h3>
+                  <p>Result Database: {response.database.name}</p>
                 </div>
               </div>
               <div slot="footer">Results provided by <a href="https://www.ChipNDoodle.com">Chip-N-Doodle</a></div>
@@ -44,7 +56,8 @@
     </template>
     <template lwc:else>
       <div class="slds-var-p-around_medium">
-        <h3 class="slds-text-body_regular">Click <strong>Refresh</strong> button above to see the latest information.</h3>
+        <h3 class="slds-text-body_regular">Click <strong>Refresh</strong> button above to see the latest information.
+        </h3>
         <p>{errorMessage}</p>
       </div>
 

--- a/force-app/main/default/lwc/microchipLookup/microchipLookup.js
+++ b/force-app/main/default/lwc/microchipLookup/microchipLookup.js
@@ -32,6 +32,7 @@ export default class MicrochipLookup extends LightningElement {
     @track resultObject;
     @api recordId;
     @track errorMessage;
+    @track showImages = false;
 
     @track mc_num;
 
@@ -118,13 +119,20 @@ export default class MicrochipLookup extends LightningElement {
         this.resultsFound = false;
         this.isLoading = true;
 
+        // Check if images are allowed
+        if (this.myCustomSettings.data.animalshelters__Allow_Images__c) {
+            console.log("IMAGES ALLOWED");
+            this.showImages = true;
+        } else {
+            this.showImages = false;
+        }
+
         // Ensure API Key has been set
         if (!this.myCustomSettings.data.animalshelters__microchip_api_Token__c) {
             this.errorMessage = "No API Token found. Please update your API token in Animal Shelter Settings > Integration.";
             this.handleErrorMessage(this.errorMessage);
             return;
         }
-
 
         // Ensure there is a MicroChip Number
         if (!this.mc_num || this.mc_num === "No MicroChip Number Found. Please Update the record.") {
@@ -145,8 +153,8 @@ export default class MicrochipLookup extends LightningElement {
             token: this.myCustomSettings.data.animalshelters__microchip_api_Token__c,
             uid: this.mc_num,
         };
-        console.log("Sending Request")
-        console.log(REC_BODY)
+        //console.log("Sending Request")
+        //console.log(REC_BODY)
 
         fetch(ENDPOINT, {
             method: POST_METHOD,
@@ -179,12 +187,14 @@ export default class MicrochipLookup extends LightningElement {
 
             // Check we actually have data
             if (!recDetails || recDetails.length === 0) {
-                this.errorMessage = "A response was received although there was no microchip information found."
+                this.errorMessage = "The response from ChipNDoodle was not in the expected format. Please check your API key and if correct, check with ChipNDoodle support."
                 this.handleErrorMessage(this.errorMessage);
                 return
             }
+
+            // Check Responses key is found is of greater length than 0
             if (!recDetails.responses || recDetails.responses.length === 0) {
-                this.errorMessage = "A response was received although the responses from the API was empty."
+                this.errorMessage = "No matches were found for this microchip ID."
                 this.handleErrorMessage(this.errorMessage);
                 return
             } else {

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Allow_Images__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Allow_Images__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Allow_Images__c</fullName>
+    <defaultValue>false</defaultValue>
+    <description>Allow Images from ChipNDoodle</description>
+    <externalId>false</externalId>
+    <label>Allow Images</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Breeds_Migration_Complete__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Breeds_Migration_Complete__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Breeds_Migration_Complete__c</fullName>
     <defaultValue>true</defaultValue>
+    <deprecated>false</deprecated>
     <description>Indicates that the migration to the Breeds object has been completed.</description>
     <externalId>false</externalId>
     <label>Breeds Migration Complete</label>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Default_Animal_Name_Prefix__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Default_Animal_Name_Prefix__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Default_Animal_Name_Prefix__c</fullName>
+    <deprecated>false</deprecated>
     <description>[Animal Shelter] Set a prefix for the Animal Name if using the default animal name creation, i.e. Site name</description>
     <externalId>false</externalId>
     <inlineHelpText>Set a prefix for the Animal Name if using the default animal name creation, i.e. Site name</inlineHelpText>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Default_Animal_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Default_Animal_Name__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Default_Animal_Name__c</fullName>
     <defaultValue>false</defaultValue>
+    <deprecated>false</deprecated>
     <description>[Animal Shelter] Set this option if you want create a Animal Name automatically based on the Record Name.</description>
     <externalId>false</externalId>
     <inlineHelpText>Set this option if you want create a Animal Name automatically based on the Record Name.</inlineHelpText>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Disable_Behaviour_Update__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Disable_Behaviour_Update__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Disable_Behaviour_Update__c</fullName>
     <defaultValue>false</defaultValue>
+    <deprecated>false</deprecated>
     <description>[Animal Shelter] By default when animal behaviours are updated on an assessment record the animal record is updated to reflect the new statuses.  Checking this setting disables the default behaviour</description>
     <externalId>false</externalId>
     <label>Disable Behaviour Update</label>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Animal_Action_Tasks__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Animal_Action_Tasks__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Enable_Animal_Action_Tasks__c</fullName>
     <defaultValue>true</defaultValue>
+    <deprecated>false</deprecated>
     <description>When enabled Tasks are created for each Animal Action record. Default enabled</description>
     <externalId>false</externalId>
     <label>Enable Animal Action Tasks</label>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Auto_Match__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Auto_Match__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Enable_Auto_Match__c</fullName>
     <defaultValue>true</defaultValue>
+    <deprecated>false</deprecated>
     <description>Enables the Adoption auto match functions</description>
     <externalId>false</externalId>
     <label>Enable Auto Match</label>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Movement_Tasks__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Enable_Movement_Tasks__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Enable_Movement_Tasks__c</fullName>
     <defaultValue>true</defaultValue>
+    <deprecated>false</deprecated>
     <description>When checked tasks are created for each Movement record created. Default is enabled</description>
     <externalId>false</externalId>
     <label>Enable Movement Tasks</label>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Task_Queue_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/Task_Queue_Name__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Task_Queue_Name__c</fullName>
+    <deprecated>false</deprecated>
     <description>[Animal Shelter] Used by flows to assign Tasks to a Queue rather than record Owner, if populated.</description>
     <externalId>false</externalId>
     <inlineHelpText>Please use the Tasks API/Developer Name</inlineHelpText>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/What3Words_API_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/What3Words_API_Key__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>What3Words_API_Key__c</fullName>
+    <deprecated>false</deprecated>
     <description>[Animal Shelter] API Key for What3Word integration</description>
     <externalId>false</externalId>
     <inlineHelpText>API Key for What3Word integration</inlineHelpText>

--- a/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/microchip_api_Token__c.field-meta.xml
+++ b/force-app/main/default/objects/Animal_Shelter_Settings__c/fields/microchip_api_Token__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>microchip_api_Token__c</fullName>
+    <deprecated>false</deprecated>
     <externalId>false</externalId>
     <label>Microchip API Token</label>
     <length>255</length>


### PR DESCRIPTION
- Added new setting for hiding images from ChipNDoodle. When enabled images of animals returned from the API are allowed, otherwise they are blocked and a placeholder icon is shown instead.
- Improved the error messages for ChipNDoodle responses.
