### PR TITLE
Image Carousel LWC Added

### DIFF
--- a/force-app/main/default/classes/RecordImageCarouselController.cls
+++ b/force-app/main/default/classes/RecordImageCarouselController.cls
@@ -1,0 +1,100 @@
+/**
+ * @description       : Apex controller for Record Image Gallery LWC component
+ * @author            : Stewart Anderson
+ * @group             :
+ * @last modified on  : 01-09-2025
+ * @last modified by  : Stewart Anderson
+**/
+public with sharing class RecordImageCarouselController {
+
+    /**
+     * @description Get related image files for a given record
+     * @param recordId The Id of the record
+     * @return List of ImageWrapper containing image information
+     */
+    @AuraEnabled(cacheable=true)
+    public static List<ImageWrapper> getRelatedImages(Id recordId) {
+        List<ImageWrapper> imageList = new List<ImageWrapper>();
+
+        try {
+            System.debug('RecordImageCarousel: Getting images for record: ' + recordId);
+
+            // Define supported image file extensions
+            Set<String> imageExtensions = new Set<String>{
+                'jpg', 'jpeg', 'png', 'gif', 'bmp', 'heic', 'heif', 'webp', 'avif'
+            };
+
+            // Query ContentDocumentLinks to find files related to this record
+            List<ContentDocumentLink> documentLinks = [
+                SELECT ContentDocumentId
+                FROM ContentDocumentLink
+                WHERE LinkedEntityId = :recordId
+                AND ShareType IN ('V', 'C', 'I')
+            ];
+
+            System.debug('RecordImageCarousel: Found ' + documentLinks.size() + ' document links');
+
+            if (documentLinks.isEmpty()) {
+                return imageList;
+            }
+
+            // Extract ContentDocument Ids
+            Set<Id> documentIds = new Set<Id>();
+            for (ContentDocumentLink link : documentLinks) {
+                documentIds.add(link.ContentDocumentId);
+            }
+
+            // Query ContentVersions to get the latest version of each document
+            List<ContentVersion> contentVersions = [
+                SELECT Id, Title, FileExtension, ContentSize, ContentDocumentId
+                FROM ContentVersion
+                WHERE ContentDocumentId IN :documentIds
+                AND IsLatest = true
+                ORDER BY CreatedDate DESC
+            ];
+
+            System.debug('RecordImageCarousel: Found ' + contentVersions.size() + ' content versions');
+
+            // Filter for image files and create ImageWrapper objects
+            for (ContentVersion cv : contentVersions) {
+                System.debug('RecordImageCarousel: Processing file: ' + cv.Title + ' with extension: ' + cv.FileExtension);
+
+                if (cv.FileExtension != null &&
+                    imageExtensions.contains(cv.FileExtension.toLowerCase())) {
+
+                    ImageWrapper wrapper = new ImageWrapper();
+                    wrapper.contentVersionId = cv.Id;
+                    wrapper.title = cv.Title;
+                    wrapper.fileExtension = cv.FileExtension;
+                    wrapper.contentSize = cv.ContentSize;
+                    wrapper.downloadUrl = '/sfc/servlet.shepherd/version/download/' + cv.Id;
+
+                    imageList.add(wrapper);
+                    System.debug('RecordImageCarousel: Added image: ' + cv.Title);
+                }
+            }
+
+            System.debug('RecordImageCarousel: Returning ' + imageList.size() + ' images');
+
+        } catch (Exception e) {
+            // Log the error and throw an AuraHandledException
+            System.debug('Error in getRelatedImages: ' + e.getMessage());
+            System.debug('Stack trace: ' + e.getStackTraceString());
+            throw new AuraHandledException('Error retrieving images: ' + e.getMessage());
+        }
+
+        return imageList;
+    }
+
+
+    /**
+     * @description Wrapper class for image information
+     */
+    public class ImageWrapper {
+        @AuraEnabled public String contentVersionId {get; set;}
+        @AuraEnabled public String title {get; set;}
+        @AuraEnabled public String fileExtension {get; set;}
+        @AuraEnabled public Integer contentSize {get; set;}
+        @AuraEnabled public String downloadUrl {get; set;}
+    }
+}

--- a/force-app/main/default/classes/RecordImageCarouselController.cls-meta.xml
+++ b/force-app/main/default/classes/RecordImageCarouselController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/RecordImageCarouselControllerTest.cls
+++ b/force-app/main/default/classes/RecordImageCarouselControllerTest.cls
@@ -1,0 +1,127 @@
+/**
+ * @description       : Test class for RecordImageCarouselController
+ * @author            : Stewart Anderson
+ * @group             :
+ * @last modified on  : 01-09-2025
+ * @last modified by  : Stewart Anderson
+**/
+@isTest
+public with sharing class RecordImageCarouselControllerTest {
+
+    @TestSetup
+    static void setupTestData() {
+        // Create a test account
+        Account testAccount = new Account(Name = 'Test Account');
+        insert testAccount;
+
+        // Create test content documents and versions
+        ContentVersion cv1 = new ContentVersion(
+            Title = 'Test Image 1',
+            PathOnClient = 'test1.jpg',
+            VersionData = Blob.valueOf('Test Image Content 1')
+        );
+        insert cv1;
+
+        ContentVersion cv2 = new ContentVersion(
+            Title = 'Test Image 2',
+            PathOnClient = 'test2.png',
+            VersionData = Blob.valueOf('Test Image Content 2')
+        );
+        insert cv2;
+
+        ContentVersion cv3 = new ContentVersion(
+            Title = 'Test Document',
+            PathOnClient = 'test.pdf',
+            VersionData = Blob.valueOf('Test PDF Content')
+        );
+        insert cv3;
+
+        // Get ContentDocument Ids
+        List<ContentVersion> insertedVersions = [
+            SELECT ContentDocumentId
+            FROM ContentVersion
+            WHERE Id IN (:cv1.Id, :cv2.Id, :cv3.Id)
+        ];
+
+        // Create ContentDocumentLinks to associate files with the account
+        List<ContentDocumentLink> linksToInsert = new List<ContentDocumentLink>();
+        for (ContentVersion cv : insertedVersions) {
+            ContentDocumentLink link = new ContentDocumentLink(
+                ContentDocumentId = cv.ContentDocumentId,
+                LinkedEntityId = testAccount.Id,
+                ShareType = 'V'
+            );
+            linksToInsert.add(link);
+        }
+        insert linksToInsert;
+    }
+
+    @isTest
+    static void testGetRelatedImages_WithImages() {
+        // Get test account
+        Account testAccount = [SELECT Id FROM Account WHERE Name = 'Test Account' LIMIT 1];
+
+        Test.startTest();
+        List<RecordImageCarouselController.ImageWrapper> result =
+            RecordImageCarouselController.getRelatedImages(testAccount.Id);
+        Test.stopTest();
+
+        // Should return 2 images (jpg and png), but not the pdf
+        System.assertEquals(2, result.size(), 'Should return 2 image files');
+
+        // Verify image properties
+        for (RecordImageCarouselController.ImageWrapper wrapper : result) {
+            System.assertNotEquals(null, wrapper.contentVersionId, 'ContentVersionId should not be null');
+            System.assertNotEquals(null, wrapper.title, 'Title should not be null');
+            System.assertNotEquals(null, wrapper.downloadUrl, 'Download URL should not be null');
+            System.assert(
+                wrapper.fileExtension == 'jpg' || wrapper.fileExtension == 'png',
+                'File extension should be jpg or png'
+            );
+        }
+    }
+
+    @isTest
+    static void testGetRelatedImages_NoImages() {
+        // Create account with no related files
+        Account testAccount = new Account(Name = 'Empty Account');
+        insert testAccount;
+
+        Test.startTest();
+        List<RecordImageCarouselController.ImageWrapper> result =
+            RecordImageCarouselController.getRelatedImages(testAccount.Id);
+        Test.stopTest();
+
+        System.assertEquals(0, result.size(), 'Should return empty list when no images found');
+    }
+
+    @isTest
+    static void testGetRelatedImages_InvalidRecordId() {
+        // Test with a valid Id format but non-existent record
+        Id fakeId = '001000000000000AAA';
+
+        Test.startTest();
+        List<RecordImageCarouselController.ImageWrapper> result =
+            RecordImageCarouselController.getRelatedImages(fakeId);
+        Test.stopTest();
+
+        System.assertEquals(0, result.size(), 'Should return empty list for non-existent record');
+    }
+
+    @isTest
+    static void testImageWrapper() {
+        // Test the ImageWrapper class
+        RecordImageCarouselController.ImageWrapper wrapper = new RecordImageCarouselController.ImageWrapper();
+        wrapper.contentVersionId = 'test123';
+        wrapper.title = 'Test Title';
+        wrapper.fileExtension = 'jpg';
+        wrapper.contentSize = 1024;
+        wrapper.downloadUrl = '/test/url';
+
+        System.assertEquals('test123', wrapper.contentVersionId);
+        System.assertEquals('Test Title', wrapper.title);
+        System.assertEquals('jpg', wrapper.fileExtension);
+        System.assertEquals(1024, wrapper.contentSize);
+        System.assertEquals('/test/url', wrapper.downloadUrl);
+    }
+}

--- a/force-app/main/default/classes/RecordImageCarouselControllerTest.cls-meta.xml
+++ b/force-app/main/default/classes/RecordImageCarouselControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/flexipages/Animal_Alert_Desktop_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Animal_Alert_Desktop_Record_Page.flexipage-meta.xml
@@ -65,12 +65,6 @@
                 <identifier>RecordSeverity_Level_cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.External_Id__c</fieldItem>
-                <identifier>Recordanimalshelters__External_Id__cField</identifier>
-            </fieldInstance>
-        </itemInstances>
         <name>Facet-e4493684-ec5a-4587-8870-1d5482cbb764</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -240,6 +234,10 @@
                     <value>Facet-503bb088-3515-417c-ac8e-cdb2f55a8c93</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>Information</value>
                 </componentInstanceProperties>
@@ -252,6 +250,10 @@
                 <componentInstanceProperties>
                     <name>columns</name>
                     <value>Facet-a0c61e89-369e-4885-80a5-773b50a047b9</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -274,8 +276,55 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>carouselHeight</name>
+                    <value>400</value>
+                </componentInstanceProperties>
+                <componentName>recordImageCarousel</componentName>
+                <identifier>animalshelters_recordImageCarousel</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Animal_Alert__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>AttachedContentDocuments</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!$Client.formFactor}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Large</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
                     <name>columns</name>
                     <value>Facet-cdb97994-a1c4-4ae2-a7f1-de6f55724120</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>

--- a/force-app/main/default/flexipages/Assessment_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Assessment_Record_Page.flexipage-meta.xml
@@ -73,12 +73,6 @@
                 <identifier>RecordCategory_cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.External_Id__c</fieldItem>
-                <identifier>Recordanimalshelters__External_Id__cField</identifier>
-            </fieldInstance>
-        </itemInstances>
         <name>Facet-9cb348dd-c2b1-489e-8c93-93b664cc0fc9</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -592,6 +586,10 @@
                     <value>Facet-550957d3-44ea-49a2-853b-0b21949c4a61</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>Information</value>
                 </componentInstanceProperties>
@@ -620,6 +618,10 @@
                     <value>Facet-843f443e-34c7-4754-92dd-fab1351d9fe2</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>General Assessment Comments</value>
                 </componentInstanceProperties>
@@ -632,6 +634,10 @@
                 <componentInstanceProperties>
                     <name>columns</name>
                     <value>Facet-754d7025-299b-4b21-81e8-361508102ff7</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -648,6 +654,10 @@
                     <value>Facet-1661efcc-27c6-42e1-8a04-76e88612a54a</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>Health Overview</value>
                 </componentInstanceProperties>
@@ -660,6 +670,10 @@
                 <componentInstanceProperties>
                     <name>columns</name>
                     <value>Facet-6fa0eb1d-6da9-4694-9042-ed80f2a36338</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -689,6 +703,10 @@
                     <value>Facet-2bbf56bf-8746-49d0-8ca4-2b13046cea68</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>Parasites/Disease</value>
                 </componentInstanceProperties>
@@ -716,6 +734,10 @@
                     <value>Facet-49e20151-4b66-43f5-83be-2b5a55dde963</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>System Information</value>
                 </componentInstanceProperties>
@@ -737,6 +759,66 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Assessment__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>AttachedContentNotes</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-6c9632e6-a12c-43db-bca8-c6dab923a659</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Assessment__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>AttachedContentDocuments</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer3</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-91m4hmgargr</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
                     <name>active</name>
                     <value>true</value>
                 </componentInstanceProperties>
@@ -750,6 +832,34 @@
                 </componentInstanceProperties>
                 <componentName>flexipage:tab</componentName>
                 <identifier>detailTab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-6c9632e6-a12c-43db-bca8-c6dab923a659</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Standard.Tab.crisisCenterNotes</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>flexipage_tab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-91m4hmgargr</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Files</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>flexipage_tab2</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>
@@ -774,6 +884,10 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>showLegacyActivityComposer</name>
+                    <value>false</value>
+                </componentInstanceProperties>
                 <componentName>runtime_sales_activities:activityPanel</componentName>
                 <identifier>runtime_sales_activities_activityPanel</identifier>
             </componentInstance>
@@ -845,27 +959,11 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
-                    <name>parentFieldApiName</name>
-                    <value>Assessment__c.Id</value>
+                    <name>carouselHeight</name>
+                    <value>400</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListApiName</name>
-                    <value>CombinedAttachments</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListComponentOverride</name>
-                    <value>NONE</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>rowsToDisplay</name>
-                    <value>10</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>showActionBar</name>
-                    <value>true</value>
-                </componentInstanceProperties>
-                <componentName>force:relatedListSingleContainer</componentName>
-                <identifier>force_relatedListSingleContainer2</identifier>
+                <componentName>recordImageCarousel</componentName>
+                <identifier>animalshelters_recordImageCarousel</identifier>
             </componentInstance>
         </itemInstances>
         <mode>Replace</mode>

--- a/force-app/main/default/flexipages/Condition_Desktop_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Condition_Desktop_Record_Page.flexipage-meta.xml
@@ -29,6 +29,10 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>showLegacyActivityComposer</name>
+                    <value>false</value>
+                </componentInstanceProperties>
                 <componentName>runtime_sales_activities:activityPanel</componentName>
                 <identifier>runtime_sales_activities_activityPanel</identifier>
             </componentInstance>
@@ -70,6 +74,66 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Condition__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>AttachedContentNotes</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-7ce38a87-27d7-4c32-b9d9-4abbd8abf886</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>Condition__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>AttachedContentDocuments</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListComponentOverride</name>
+                    <value>NONE</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>rowsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentName>force:relatedListSingleContainer</componentName>
+                <identifier>force_relatedListSingleContainer3</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-yzv148388tk</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
                     <name>active</name>
                     <value>true</value>
                 </componentInstanceProperties>
@@ -99,6 +163,34 @@
                 <identifier>customTab</identifier>
             </componentInstance>
         </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-7ce38a87-27d7-4c32-b9d9-4abbd8abf886</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Standard.Tab.crisisCenterNotes</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>flexipage_tab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-yzv148388tk</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Files</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>flexipage_tab2</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>Facet-f9e0073d-21c8-4c18-b9b3-502df604cefd</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -126,6 +218,10 @@
     <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Short_Description__c</fieldItem>
                 <identifier>RecordShort_Description__cField</identifier>
             </fieldInstance>
@@ -170,12 +266,6 @@
                 <identifier>RecordAnimal__cField</identifier>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.External_Id__c</fieldItem>
-                <identifier>Recordanimalshelters__External_Id__cField</identifier>
-            </fieldInstance>
-        </itemInstances>
         <name>Facet-4c5a0987-2949-4f04-bd61-2a752918f3f3</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -199,6 +289,10 @@
                 <componentInstanceProperties>
                     <name>columns</name>
                     <value>Facet-a125e0af-0b2f-402a-9eda-68244000c7d0</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -277,6 +371,10 @@
                     <value>Facet-574adc46-820c-47d1-a0cb-48c9b1be8465</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>label</name>
                     <value>System Information</value>
                 </componentInstanceProperties>
@@ -328,6 +426,16 @@
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>carouselHeight</name>
+                    <value>400</value>
+                </componentInstanceProperties>
+                <componentName>recordImageCarousel</componentName>
+                <identifier>animalshelters_recordImageCarousel</identifier>
+            </componentInstance>
+        </itemInstances>
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>

--- a/force-app/main/default/layouts/Animal_Alert__c-Animal Alert Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Animal_Alert__c-Animal Alert Layout.layout-meta.xml
@@ -70,10 +70,6 @@
                 <behavior>Readonly</behavior>
                 <field>Name</field>
             </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>External_Id__c</field>
-            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
@@ -146,6 +142,12 @@
         </platformActionListItems>
     </platformActionList>
     <relatedLists>
+        <relatedList>RelatedFileList</relatedList>
+    </relatedLists>
+    <relatedLists>
+        <relatedList>RelatedContentNoteList</relatedList>
+    </relatedLists>
+    <relatedLists>
         <fields>TASK.SUBJECT</fields>
         <fields>TASK.WHO_NAME</fields>
         <fields>ACTIVITY.TASK</fields>
@@ -170,7 +172,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8F000006l3LA</masterLabel>
+        <masterLabel>00h4L000000RJEp</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Assessment__c-Assessment Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Assessment__c-Assessment Layout.layout-meta.xml
@@ -194,10 +194,6 @@
                 <behavior>Readonly</behavior>
                 <field>CreatedById</field>
             </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>External_Id__c</field>
-            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -220,14 +216,14 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>NewTask</actionName>
-            <actionType>QuickAction</actionType>
-            <sortOrder>1</sortOrder>
-        </platformActionListItems>
-        <platformActionListItems>
             <actionName>NewEvent</actionName>
             <actionType>QuickAction</actionType>
             <sortOrder>0</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>NewTask</actionName>
+            <actionType>QuickAction</actionType>
+            <sortOrder>1</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>NewContact</actionName>
@@ -295,13 +291,16 @@
         <relatedList>RelatedHistoryList</relatedList>
     </relatedLists>
     <relatedLists>
-        <relatedList>RelatedNoteList</relatedList>
-    </relatedLists>
-    <relatedLists>
         <fields>NAME</fields>
         <fields>Short_Description__c</fields>
         <fields>Start_Date__c</fields>
         <relatedList>Condition__c.Assessment__c</relatedList>
+    </relatedLists>
+    <relatedLists>
+        <relatedList>RelatedFileList</relatedList>
+    </relatedLists>
+    <relatedLists>
+        <relatedList>RelatedContentNoteList</relatedList>
     </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>
@@ -309,7 +308,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8F000006l3LD</masterLabel>
+        <masterLabel>00h4L000000URxM</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Condition__c-Condition Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Condition__c-Condition Layout.layout-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
+    <excludeButtons>OpenSlackRecordChannel</excludeButtons>
     <excludeButtons>Submit</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
@@ -53,10 +54,6 @@
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>CreatedById</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>External_Id__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
@@ -159,6 +156,12 @@
         <relatedList>RelatedHistoryList</relatedList>
     </relatedLists>
     <relatedLists>
+        <relatedList>RelatedContentNoteList</relatedList>
+    </relatedLists>
+    <relatedLists>
+        <relatedList>RelatedFileList</relatedList>
+    </relatedLists>
+    <relatedLists>
         <fields>NAME</fields>
         <fields>Animal__c</fields>
         <fields>Date_Time_of_Treatment__c</fields>
@@ -187,7 +190,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8F000006l3LF</masterLabel>
+        <masterLabel>00h4L000000RJEs</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/lwc/recordImageCarousel/__tests__/recordImageCarousel.test.js
+++ b/force-app/main/default/lwc/recordImageCarousel/__tests__/recordImageCarousel.test.js
@@ -1,0 +1,147 @@
+import { createElement } from 'lwc';
+import RecordImageCarousel from 'c/recordImageCarousel';
+import getRelatedImages from '@salesforce/apex/RecordImageCarouselController.getRelatedImages';
+
+// Mock the Apex method
+jest.mock(
+    '@salesforce/apex/RecordImageCarouselController.getRelatedImages',
+    () => {
+        const { createApexTestWireAdapter } = require('@salesforce/sfdx-lwc-jest');
+        return {
+            default: createApexTestWireAdapter(jest.fn())
+        };
+    },
+    { virtual: true }
+);
+
+describe('c-record-image-carousel', () => {
+    afterEach(() => {
+        // The jsdom instance is shared across test cases in a single file so reset the DOM
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('displays loading spinner initially', () => {
+        const element = createElement('c-record-image-carousel', {
+            is: RecordImageCarousel
+        });
+        element.recordId = '001000000000001';
+        document.body.appendChild(element);
+
+        // Check if loading spinner is displayed
+        const spinner = element.shadowRoot.querySelector('lightning-spinner');
+        expect(spinner).toBeTruthy();
+    });
+
+    it('displays images when data is loaded', () => {
+        const mockImages = [
+            {
+                contentVersionId: '068000000000001',
+                title: 'Test Image 1',
+                fileExtension: 'jpg',
+                contentSize: 1024,
+                downloadUrl: '/sfc/servlet.shepherd/version/download/068000000000001'
+            },
+            {
+                contentVersionId: '068000000000002',
+                title: 'Test Image 2',
+                fileExtension: 'png',
+                contentSize: 2048,
+                downloadUrl: '/sfc/servlet.shepherd/version/download/068000000000002'
+            }
+        ];
+
+        const element = createElement('c-record-image-carousel', {
+            is: RecordImageCarousel
+        });
+        element.recordId = '001000000000001';
+        document.body.appendChild(element);
+
+        // Emit data from the wire adapter
+        getRelatedImages.emit(mockImages);
+
+        return Promise.resolve().then(() => {
+            // Check if carousel is displayed
+            const carousel = element.shadowRoot.querySelector('lightning-carousel');
+            expect(carousel).toBeTruthy();
+            
+            // Check if loading spinner is hidden
+            const spinner = element.shadowRoot.querySelector('lightning-spinner');
+            expect(spinner).toBeFalsy();
+        });
+    });
+
+    it('displays no images message when no data', () => {
+        const element = createElement('c-record-image-carousel', {
+            is: RecordImageCarousel
+        });
+        element.recordId = '001000000000001';
+        document.body.appendChild(element);
+
+        // Emit empty data from the wire adapter
+        getRelatedImages.emit([]);
+
+        return Promise.resolve().then(() => {
+            // Check if no images message is displayed
+            const noImagesText = element.shadowRoot.querySelector('p');
+            expect(noImagesText.textContent).toBe('No images found for this record');
+            
+            // Check if carousel is not displayed
+            const carousel = element.shadowRoot.querySelector('lightning-carousel');
+            expect(carousel).toBeFalsy();
+        });
+    });
+
+    it('applies custom height property', () => {
+        const element = createElement('c-record-image-carousel', {
+            is: RecordImageCarousel
+        });
+        element.recordId = '001000000000001';
+        element.carouselHeight = 600;
+        document.body.appendChild(element);
+
+        const mockImages = [
+            {
+                contentVersionId: '068000000000001',
+                title: 'Test Image 1',
+                fileExtension: 'jpg',
+                contentSize: 1024,
+                downloadUrl: '/sfc/servlet.shepherd/version/download/068000000000001'
+            }
+        ];
+
+        // Emit data from the wire adapter
+        getRelatedImages.emit(mockImages);
+
+        return Promise.resolve().then(() => {
+            const carousel = element.shadowRoot.querySelector('lightning-carousel');
+            expect(carousel.style.cssText).toContain('height: 600px');
+        });
+    });
+
+    it('handles error from wire adapter', () => {
+        const element = createElement('c-record-image-carousel', {
+            is: RecordImageCarousel
+        });
+        element.recordId = '001000000000001';
+        document.body.appendChild(element);
+
+        // Mock the toast event
+        const mockDispatchEvent = jest.fn();
+        element.dispatchEvent = mockDispatchEvent;
+
+        // Emit error from the wire adapter
+        getRelatedImages.error({ body: { message: 'Test error' } });
+
+        return Promise.resolve().then(() => {
+            // Check if error toast was dispatched
+            expect(mockDispatchEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'lightning__showtoast'
+                })
+            );
+        });
+    });
+});

--- a/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.css
+++ b/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.css
@@ -1,0 +1,39 @@
+:host {
+    --carousel-height: 400px;
+}
+
+.carousel-container {
+    width: 100%;
+}
+
+.carousel {
+    height: var(--carousel-height);
+    width: 100%;
+}
+
+
+/* Modal styles */
+.modal-image-container {
+    text-align: center;
+    max-height: 85vh;
+    overflow: auto;
+}
+
+.modal-image {
+    max-width: 100%;
+    max-height: 85vh;
+    object-fit: contain;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Make modal container larger */
+.large-modal .slds-modal__container {
+    max-width: 90vw;
+    width: 90vw;
+}
+
+/* Make carousel images clickable */
+.carousel-item-container lightning-carousel-image {
+    cursor: pointer;
+}

--- a/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.html
+++ b/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.html
@@ -1,0 +1,86 @@
+<template>
+    <lightning-card title="Image Gallery" icon-name="utility:image">
+        <div if:true={hasImages} class="slds-p-around_medium carousel-container">
+            <lightning-carousel 
+                class="carousel" 
+                disable-auto-scroll="true"
+                disable-auto-refresh="true">
+                <template for:each={imageData} for:item="image" for:index="index">
+                    <lightning-carousel-image
+                        key={image.contentVersionId}
+                        src={image.downloadUrl}
+                        header={image.title}
+                        description={image.description}
+                        alternative-text={image.title}
+                        onclick={handleImageClick}
+                        data-image-id={image.contentVersionId}>
+                    </lightning-carousel-image>
+                </template>
+            </lightning-carousel>
+        </div>
+        
+        <div if:false={hasImages} class="slds-p-around_medium slds-text-align_center">
+            <lightning-icon icon-name="utility:image" size="large" class="slds-m-bottom_small"></lightning-icon>
+            <p class="slds-text-color_weak">No images found for this record</p>
+        </div>
+        
+        <div class="slds-p-around_small slds-text-align_center">
+            <lightning-file-upload
+                label="Upload Image"
+                multiple="false"
+                name="imageUploader"
+                accept={acceptedFormats}
+                record-id={recordId}
+                onuploadfinished={handleUploadFinished}
+                disabled={isLoading}>
+            </lightning-file-upload>
+        </div>
+        
+        <div if:true={isLoading} class="slds-p-around_medium slds-text-align_center">
+            <lightning-spinner alternative-text="Loading images..." size="medium"></lightning-spinner>
+        </div>
+    </lightning-card>
+
+    <!-- Modal for expanded image view -->
+    <template if:true={showModal}>
+        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open large-modal" aria-labelledby="modal-heading-01" aria-modal="true" aria-describedby="modal-content-id-1">
+            <div class="slds-modal__container">
+                <header class="slds-modal__header">
+                    <lightning-button-icon
+                        icon-name="utility:close"
+                        onclick={closeModal}
+                        alternative-text="Close"
+                        variant="bare-inverse"
+                        class="slds-modal__close">
+                    </lightning-button-icon>
+                    <h2 id="modal-heading-01" class="slds-modal__title slds-hyphenate">
+                        {selectedImage.title}
+                    </h2>
+                </header>
+                <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
+                    <div class="modal-image-container">
+                        <img 
+                            src={selectedImage.downloadUrl} 
+                            alt={selectedImage.title}
+                            class="modal-image" />
+                    </div>
+                    <div class="slds-m-top_medium slds-text-align_center">
+                        <lightning-button
+                            variant="brand"
+                            label="Download"
+                            icon-name="utility:download"
+                            onclick={handleModalDownload}
+                            class="slds-m-right_small">
+                        </lightning-button>
+                        <lightning-button
+                            variant="neutral"
+                            label="Close"
+                            onclick={closeModal}>
+                        </lightning-button>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <div class="slds-backdrop slds-backdrop_open"></div>
+    </template>
+</template>

--- a/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.js
+++ b/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.js
@@ -1,0 +1,231 @@
+/**
+ * @description       : LWC component to display related image files in a carousel
+ * @author            : Stewart Anderson
+ * @group             :
+ * @last modified on  : 01-09-2025
+ * @last modified by  : Stewart Anderson
+**/
+import { LightningElement, api, wire } from 'lwc';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+import { refreshApex } from '@salesforce/apex';
+import getRelatedImages from '@salesforce/apex/RecordImageCarouselController.getRelatedImages';
+
+export default class RecordImageCarousel extends LightningElement {
+    @api recordId;
+    @api carouselHeight = 400; // Default height in pixels
+
+    imageData = [];
+    isLoading = true;
+    showModal = false;
+    selectedImage = {};
+    wiredImagesResult;
+    refreshInterval;
+    lastImageCount = 0;
+    
+    connectedCallback() {
+        // Set up auto-refresh every 30 seconds to detect external file uploads
+        this.refreshInterval = setInterval(() => {
+            this.checkForNewImages();
+        }, 30000);
+    }
+    
+    disconnectedCallback() {
+        if (this.refreshInterval) {
+            clearInterval(this.refreshInterval);
+        }
+    }
+    
+    renderedCallback() {
+        // Set the custom height CSS property
+        if (this.template.host) {
+            this.template.host.style.setProperty('--carousel-height', `${this.carouselHeight}px`);
+        }
+    }
+
+    // Wire method to get related images
+    @wire(getRelatedImages, { recordId: '$recordId' })
+    wiredImages(result) {
+        this.wiredImagesResult = result;
+        const { error, data } = result;
+        this.isLoading = true;
+        if (data) {
+            this.processImages(data);
+            this.isLoading = false;
+        } else if (error) {
+            this.handleError(error);
+            this.isLoading = false;
+        } else {
+        }
+    }
+
+    // Process the images for the carousel
+    processImages(images) {
+        
+        if (images && images.length > 0) {
+            // Store images with formatted descriptions directly
+            this.imageData = images.map(image => ({
+                contentVersionId: image.contentVersionId,
+                downloadUrl: image.downloadUrl,
+                title: image.title,
+                description: `File size: ${this.formatFileSize(image.contentSize)}`,
+                fileExtension: image.fileExtension,
+                contentSize: image.contentSize
+            }));
+            
+            // Update last image count for auto-refresh detection
+            this.lastImageCount = this.imageData.length;
+        } else {
+            this.imageData = [];
+        }
+    }
+
+    // Handle errors
+    handleError(error) {
+        let message = 'Unknown error';
+        if (Array.isArray(error.body)) {
+            message = error.body.map(e => e.message).join(', ');
+        } else if (typeof error.body.message === 'string') {
+            message = error.body.message;
+        }
+
+        this.dispatchEvent(
+            new ShowToastEvent({
+                title: 'Error Loading Images',
+                message,
+                variant: 'error',
+            })
+        );
+    }
+
+    // Format file size for display
+    formatFileSize(bytes) {
+        if (!bytes) return '0 Bytes';
+
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+        return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    }
+
+    // Computed properties
+    get hasImages() {
+        return this.imageData && this.imageData.length > 0;
+    }
+    
+    get imageDataLength() {
+        return this.imageData ? this.imageData.length : 0;
+    }
+
+    // Event handlers
+    handleImageClick(event) {
+        const imageId = event.target.dataset.imageId;
+        
+        // Find the clicked image
+        const clickedImage = this.imageData.find(img => img.contentVersionId === imageId);
+        if (clickedImage) {
+            this.selectedImage = clickedImage;
+            this.showModal = true;
+        }
+    }
+
+    // Set accepted image formats
+    get acceptedFormats() {
+        return ['.png', '.jpg', '.jpeg', '.webp', '.heic', '.heif', '.avif', '.bmp', '.gif'];
+    }
+
+    // Handle completed upload
+    handleUploadFinished(event) {
+        const uploadedFiles = event.detail.files;
+        if (uploadedFiles && uploadedFiles.length > 0) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Success',
+                    message: `Image "${uploadedFiles[0].name}" uploaded successfully!`,
+                    variant: 'success',
+                })
+            );
+            
+            // Refresh the component to show the new image
+            this.refreshImages();
+        }
+    }
+
+    async refreshImages() {
+        try {
+            await refreshApex(this.wiredImagesResult);
+        } catch (error) {
+            console.error('Error refreshing images:', error);
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    async checkForNewImages() {
+        try {
+            // Only check if we have a record ID and aren't currently loading
+            if (!this.recordId || this.isLoading) return;
+            
+            // Refresh to get latest count
+            await refreshApex(this.wiredImagesResult);
+            
+            // If image count increased, show notification
+            if (this.imageData.length > this.lastImageCount) {
+                this.dispatchEvent(
+                    new ShowToastEvent({
+                        title: 'New Images Detected',
+                        message: 'Image gallery has been refreshed with new content.',
+                        variant: 'info',
+                    })
+                );
+            }
+            
+            this.lastImageCount = this.imageData.length;
+        } catch (error) {
+            // Silently handle errors in background refresh
+            console.error('Error checking for new images:', error);
+        }
+    }
+
+    handleModalDownload() {
+        this.downloadImage(this.selectedImage.downloadUrl, this.selectedImage.title);
+    }
+
+    closeModal() {
+        this.showModal = false;
+        this.selectedImage = {};
+    }
+
+    downloadImage(url, filename) {
+        try {
+            // Create a temporary anchor element to trigger download
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = filename || 'image';
+            link.target = '_blank';
+            
+            // Append to body, click, and remove
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            
+            // Show success message
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Download Started',
+                    message: `Downloading ${filename}`,
+                    variant: 'success',
+                })
+            );
+        } catch (error) {
+            this.dispatchEvent(
+                new ShowToastEvent({
+                    title: 'Download Failed',
+                    message: 'Unable to download the image. Please try again.',
+                    variant: 'error',
+                })
+            );
+        }
+    }
+
+}

--- a/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.js-meta.xml
+++ b/force-app/main/default/lwc/recordImageCarousel/recordImageCarousel.js-meta.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <isExposed>true</isExposed>
+    <description>Image Gallery component that displays related image files in a carousel format</description>
+    <masterLabel>Image Gallery</masterLabel>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
+        <target>lightning__RecordAction</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <property name="carouselHeight" type="Integer" default="400"
+                label="Carousel Height (px)" description="Height of the image carousel in pixels" />
+            <supportedFormFactors>
+                <supportedFormFactor type="Large" />
+                <supportedFormFactor type="Small" />
+            </supportedFormFactors>
+        </targetConfig>
+        <targetConfig targets="lightning__HomePage">
+            <property name="carouselHeight" type="Integer" default="400"
+                label="Carousel Height (px)" description="Height of the image carousel in pixels" />
+            <supportedFormFactors>
+                <supportedFormFactor type="Large" />
+            </supportedFormFactors>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION

# Critical Changes

# Changes
- New reusable image carousel which can be added to any record page and shows any images which have been linked to the current record within related Files.

# Issues Closed
